### PR TITLE
fix the issue for lazy input component

### DIFF
--- a/addon/components/validator-wrapper.js
+++ b/addon/components/validator-wrapper.js
@@ -236,6 +236,7 @@ export default class ValidatorWrapper extends Component {
 
   @action
   onReceiveProperties(element) {
+    this._collectInputNames(element);
     this.contextualValidator(element);
   }
 


### PR DESCRIPTION
there is an use case that a downsteam component lazily renders the input field,
which cause the validation become no-op because the deferred input element is
not registered on `didInsert` event.