### PR TITLE
fix corner case

### DIFF
--- a/addon/components/validator-wrapper.js
+++ b/addon/components/validator-wrapper.js
@@ -299,6 +299,8 @@ export default class ValidatorWrapper extends Component {
       );
     }
 
-    return setProperties(this, { error });
+    if (!this.isDestroying && !this.isDestroyed) {
+      return setProperties(this, { error });
+    }
   }
 }


### PR DESCRIPTION
to avoid errors such as
```
Error: Assertion Failed: calling set on destroyed object: [object Object].error = [object Object]
```