### PR TITLE
create modifier to manually insert name attribute

### DIFF
--- a/addon/modifiers/install-name-attr.js
+++ b/addon/modifiers/install-name-attr.js
@@ -1,0 +1,26 @@
+import Modifier from 'ember-modifier';
+
+/**
+ *
+ * Add `name` attribute to the input element when it is not supported by the
+ * component API (e.g. Typeahead)
+ *
+ * @example
+ * <div {{ember-ts-job-posting$install-name-attribute "the-awesome-name"}}></div>
+ * <div {{ember-ts-job-posting$install-name-attribute "the-awesome-name" ".foo input"}}></div>
+ */
+
+export default class InstallNameAttribute extends Modifier {
+  didInstall() {
+    const [name, selector] = this.args.positional;
+    let formElement;
+    if (selector) {
+      formElement = this.element.querySelector(selector);
+    } else {
+      formElement = this.element.querySelector('input,select');
+    }
+    if (formElement) {
+      formElement.setAttribute('name', name);
+    }
+  }
+}

--- a/app/modifiers/install-name-attr.js
+++ b/app/modifiers/install-name-attr.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-form-validity/modifiers/install-name-attr';

--- a/docs/03 - Advanced usage/05 - Name attribute modifier.md
+++ b/docs/03 - Advanced usage/05 - Name attribute modifier.md
@@ -1,0 +1,44 @@
+# Name attribute injection
+
+By design, `name` attribute is required on the target `<input>` element in order to kick off the validation. However sometimes the the component that renders the element is remote and does not have the API specifying the `name` attribute. This helper allows to bind the name on the inner element.
+
+## Positional arguments
+
+#### name `{string}`
+The name string that will embed to the `<input>`
+
+#### selector `{string}` (optional)
+The DOM selector string to the `<input>` that can help the modifier to better locate it.
+
+## Without specifying the selector
+The modifier will insert `name` attribute to the first `<input>` or `<select>` element encountered
+
+```hbs
+<div data-test-element {{install-name-attr "email"}}>
+  <input
+    placeholder="username@email.com"
+    autocomplete="off"
+    type="email"
+    data-test-email
+    value={{this.email}}
+    required
+  />
+</div>
+```
+
+## Specifying the selector
+
+```hbs
+<div data-test-element {{install-name-attr "email" ".foo"}}>
+  <div class="foo">
+    <input
+      placeholder="username@email.com"
+      autocomplete="off"
+      type="email"
+      data-test-email
+      value={{this.email}}
+      required
+    />
+  </div>
+</div>
+```

--- a/tests/integration/modifiers/install-name-attr-test.js
+++ b/tests/integration/modifiers/install-name-attr-test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifier | installNameAttr', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders on <input> (without selector)', async function (assert) {
+    await render(
+      hbs`
+        <div data-test-element {{install-name-attr "the-name"}}>
+          <p><input/></p>
+        </div>
+      `
+    );
+    assert.dom('input').hasAttribute('name', 'the-name');
+  });
+
+  test('it renders on <select> (without selector)', async function (assert) {
+    await render(
+      hbs`
+        <div data-test-element {{install-name-attr "the-name"}}>
+          <p>
+            <select>
+              <option>foo</option>
+            </select>
+          </p>
+        </div>
+      `
+    );
+
+    assert.dom('select').hasAttribute('name', 'the-name');
+  });
+
+  test('it renders on any field when the selector match', async function (assert) {
+    await render(
+      hbs`
+        <div data-test-element {{install-name-attr "the-name" "p>input"}}>
+          <p><select/></p>
+          <p><input data-test-foo /></p>
+        </div>
+      `
+    );
+    assert.dom('[data-test-foo]').hasAttribute('name', 'the-name');
+  });
+});


### PR DESCRIPTION
By design, `name` attribute is required on the target `<input>` element in order to kick off the validation. However sometimes the the component that renders the element is remote and does not have the API specifying the `name` attribute. This helper allows to bind the name on the inner element.