### PR TITLE
Remove a non-existent default export

### DIFF
--- a/app/components/test.js
+++ b/app/components/test.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-form-validity/components/test';


### PR DESCRIPTION
This file in the app folder is re-exporting a file which does not exist. This is swallowed by Ember classic builds, but fails in Embroider builds.