### PR TITLE
configuration for ts

### DIFF
--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -1,3 +1,4 @@
+import 'qunit-dom';
 import Application from 'dummy/app';
 import config from 'dummy/config/environment';
 import * as QUnit from 'qunit';

--- a/types/dummy/index.d.ts
+++ b/types/dummy/index.d.ts
@@ -1,1 +1,2 @@
 // default declare file
+declare module 'dummy/app';


### PR DESCRIPTION
to resolve the issue of missing implicit type from `qunit-dom`, which produces error looks like:
```
tests/integration/modifiers/install-name-attr-test.ts:45:12 - error TS2339: Property 'dom' does not exist on type 'Assert'.
```
following the fix described in https://github.com/simplabs/qunit-dom/issues/108